### PR TITLE
issue/59 Добавить возможность выбора имени для namespace

### DIFF
--- a/testit-importer-allure/src/configurator.py
+++ b/testit-importer-allure/src/configurator.py
@@ -11,6 +11,7 @@ CONFIG_PROJECT_ID = 'projectID'
 CONFIG_CONFIGURATION_ID = 'configurationID'
 CONFIG_CERT_VALIDATION = 'certValidation'
 CONFIG_NAME = 'connection_config.ini'
+ALLURE_IGNORE_PACKAGE_NAME = 'ignorePackageName'
 
 RABBITMQ_CONFIG_SECTION = 'rabbitmq'
 RABBITMQ_CONFIG_URL = 'host'
@@ -22,6 +23,7 @@ MINIO_CONFIG_SECTION = 'minio'
 MINIO_CONFIG_URL = 'host'
 MINIO_CONFIG_ACCESS_KEY = 'accessKey'
 MINIO_CONFIG_SECRET_KEY = 'secretKey'
+
 
 
 class Configurator:
@@ -64,6 +66,10 @@ class Configurator:
             return
 
         return self.config.get(CONFIG_SECTION, CONFIG_CERT_VALIDATION)
+
+    def get_ignore_package_name(self):
+        """Function returns minio secret key."""
+        return self.config.get(CONFIG_SECTION, ALLURE_IGNORE_PACKAGE_NAME)
 
     def get_rabbitmq_url(self):
         """Function returns rabbit mq url."""
@@ -164,6 +170,15 @@ class Configurator:
             action='store_true',
             dest="show_settings",
             help='Show the connection_config.ini file'
+        )
+        self.parser.add_argument(
+            '-ipn',
+            '--ignorepackagename',
+            action="store",
+            dest="ignore_package_name",
+            metavar="True or False",
+            default=False,
+            help='Use parentSuit as namespace'
         )
         self.parser.add_argument(
             '-rd',
@@ -319,6 +334,8 @@ class Configurator:
 
         if args.set_cert_validation:
             self.config.set(CONFIG_SECTION, CONFIG_CERT_VALIDATION, args.set_cert_validation.lower())
+
+        self.config.set(CONFIG_SECTION, ALLURE_IGNORE_PACKAGE_NAME, args.ignore_package_name)
 
         if args.alluredir:
             self.path_to_results = args.alluredir

--- a/testit-importer-allure/src/importer.py
+++ b/testit-importer-allure/src/importer.py
@@ -19,6 +19,7 @@ class Importer:
         self.__testrun_id = config.specified_testrun
         self.__testrun_name = config.specified_testrun_name
         self.__configuration_id = config.get_configuration_id()
+        self.__ignore_namespace_name = config.get_ignore_package_name()
 
     def send_result(self):
         """Function imports result to TMS."""
@@ -164,7 +165,7 @@ class Importer:
                         Converter.label_to_label_post_model(
                             f"{label[f'{prefix}name']}::{label[f'{prefix}value']}"))
 
-                if label[f'{prefix}name'] == 'package':
+                if label[f'{prefix}name'] == 'package' and not self.__ignore_namespace_name:
                     packages = label[f'{prefix}value'].split('.')
 
                     while packages and not packages[-1]:


### PR DESCRIPTION
**Issue** https://github.com/testit-tms/importers/issues/59

**Примеры команд**
```
testit --resultsdir report --testrunname Test -ipn True
testit --resultsdir report --testrunname Test -ignorepackagename True
```
При добавлении флага, парсер не обращает внимание на название package, а берет parentSuit в качестве названия для namespace

**До**
![image](https://github.com/testit-tms/importers/assets/80100512/f9127716-ece1-4a0c-9fe5-2c67ba9c74c9)

**После**
![image](https://github.com/testit-tms/importers/assets/80100512/2650d06c-ecf3-46ee-9bea-5a8b9354bc2f)
